### PR TITLE
Streamline application and character monitoring

### DIFF
--- a/Services/PlayOnlineMonitorService.cs
+++ b/Services/PlayOnlineMonitorService.cs
@@ -148,10 +148,11 @@ namespace FFXIManager.Services
             if (!_isMonitoring)
             {
                 _isMonitoring = true;
-                
+                _processManagementService.AddProcessNames(_targetProcessNames);
+
                 // Start global monitoring if not already started
                 _processManagementService.StartGlobalMonitoring(TimeSpan.FromSeconds(3));
-                
+
                 _loggingService.LogInfoAsync("Started PlayOnline character monitoring", "PlayOnlineMonitorService");
             }
         }
@@ -161,6 +162,7 @@ namespace FFXIManager.Services
             if (_isMonitoring)
             {
                 _isMonitoring = false;
+                _processManagementService.RemoveProcessNames(_targetProcessNames);
                 _loggingService.LogInfoAsync("Stopped PlayOnline character monitoring", "PlayOnlineMonitorService");
             }
         }


### PR DESCRIPTION
## Summary
- centralize tracking of process names in `ProcessManagementService`
- register external applications with the shared process monitor
- hook PlayOnline monitor into shared process tracking

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_6899ee463a248328a04efefd406963dc